### PR TITLE
Dart 2.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/
 pubspec.lock
 /.idea/
+.dart_tool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changlog
 
+## 1.2.0-dev.d28.1
+
+- Dart 2.8 pre-release
+- Enable [`avoid_redundant_argument_values`](https://dart-lang.github.io/linter/lints/avoid_redundant_argument_values.html)
+- Enable [`missing_whitespace_between_adjacent_strings`](https://dart-lang.github.io/linter/lints/missing_whitespace_between_adjacent_strings.html)
+- Enable [`no_runtimeType_toString`](https://dart-lang.github.io/linter/lints/no_runtimeType_toString.html)
+- Enable [`unnecessary_string_interpolations`](https://dart-lang.github.io/linter/lints/unnecessary_string_interpolations.html)
+- Enable [`unnecessary_raw_strings`](https://dart-lang.github.io/linter/lints/unnecessary_raw_strings.html)
+- Enable [`unnecessary_string_escapes`](https://dart-lang.github.io/linter/lints/unnecessary_string_escapes.html)
+- Enable [`leading_newlines_in_multiline_strings`](https://dart-lang.github.io/linter/lints/leading_newlines_in_multiline_strings.html)
+
 ## 1.1.1
 
 - Fix syntactical error which breaks custom rules [#5](https://github.com/passsy/dart-lint/issues/5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changlog
 
+## 1.2.0-dev.d28.2
+
+Raise min sdk to `2.8.0-dev.16.0`
+
 ## 1.2.0-dev.d28.1
 
 - Dart 2.8 pre-release

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -385,6 +385,11 @@ linter:
     # https://dart-lang.github.io/linter/lints/literal_only_boolean_expressions.html
     # - literal_only_boolean_expressions
 
+    # Don't forget the whitespaces at the end
+    # Dart SDK: >= 2.8.0-dev.10.0 • (Linter v0.1.110)
+    # https://dart-lang.github.io/linter/lints/missing_whitespace_between_adjacent_strings.html
+    - missing_whitespace_between_adjacent_strings
+
     # Concat Strings obviously with `+` inside a list.
     # pedantic: disabled
     # https://dart-lang.github.io/linter/lints/no_adjacent_strings_in_list.html
@@ -398,6 +403,11 @@ linter:
     # Flutter only: `createState` shouldn't pass information into the state
     # https://dart-lang.github.io/linter/lints/no_logic_in_create_state.html
     - no_logic_in_create_state
+
+    # calling `runtimeType` may be a performance problem
+    # Dart SDK: >= 2.8.0-dev.10.0 • (Linter v0.1.110)
+    # https://dart-lang.github.io/linter/lints/no_runtimeType_toString.html
+    - no_runtimeType_toString
 
     # Follow dart style naming conventions
     # https://dart-lang.github.io/linter/lints/non_constant_identifier_names.html
@@ -749,6 +759,12 @@ linter:
     # Avoid magic overloads of + operators
     # https://dart-lang.github.io/linter/lints/unnecessary_statements.html
     - unnecessary_statements
+
+
+    # Especially with NNBD a no-brainer
+    # Dart SDK: >= 2.8.0-dev.10.0 • (Linter v0.1.110)
+    # https://dart-lang.github.io/linter/lints/unnecessary_string_interpolations.html
+    - unnecessary_string_interpolations
 
     # The variable is clear, remove clutter
     # pedantic: enabled

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -352,6 +352,11 @@ linter:
     # https://dart-lang.github.io/linter/lints/join_return_with_assignment.html
     - join_return_with_assignment
 
+    # Add leading \n which which makes multiline strings easier to read
+    # Dart SDK: >= 2.8.0-dev.16.0 • (Linter v0.1.113)
+    # https://dart-lang.github.io/linter/lints/leading_newlines_in_multiline_strings.html
+    - leading_newlines_in_multiline_strings
+
     # Makes sure a library name is a valid dart identifier.
     # This comes in handy for test files combining multiple tests where the file name can be used as identifier
     #

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -102,6 +102,11 @@ linter:
     # https://dart-lang.github.io/linter/lints/avoid_equals_and_hash_code_on_mutable_classes.html
     # - avoid_equals_and_hash_code_on_mutable_classes
 
+    # Use different quotes instead of escaping
+    # Dart SDK: >= 2.8.0-dev.11.0 • (Linter v0.1.111)
+    # https://dart-lang.github.io/linter/lints/avoid_escaping_inner_quotes.html
+    - avoid_escaping_inner_quotes
+
     # Prevents unnecessary allocation of a field
     # pedantic: disabled
     # http://dart-lang.github.io/linter/lints/avoid_field_initializers_in_const_classes.html
@@ -756,10 +761,19 @@ linter:
     # https://dart-lang.github.io/linter/lints/unnecessary_parenthesis.html
     - unnecessary_parenthesis
 
+    # Use raw string only when needed
+    # Dart SDK: >= 2.8.0-dev.11.0 • (Linter v0.1.111)
+    # https://dart-lang.github.io/linter/lints/unnecessary_raw_strings.html
+    - unnecessary_raw_strings
+
     # Avoid magic overloads of + operators
     # https://dart-lang.github.io/linter/lints/unnecessary_statements.html
     - unnecessary_statements
 
+    # Remove unnecessary escape characters
+    # Dart SDK: >= 2.8.0-dev.11.0 • (Linter v0.1.111)
+    # https://dart-lang.github.io/linter/lints/unnecessary_string_escapes.html
+    - unnecessary_string_escapes
 
     # Especially with NNBD a no-brainer
     # Dart SDK: >= 2.8.0-dev.10.0 • (Linter v0.1.110)

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -144,6 +144,11 @@ linter:
     # https://dart-lang.github.io/linter/lints/avoid_private_typedef_functions.html
     - avoid_private_typedef_functions
 
+    # Don't explicitly set defaults
+    # Dart SDK: >= 2.8.0-dev.1.0 • (Linter v0.1.107)
+    # https://dart-lang.github.io/linter/lints/avoid_redundant_argument_values.html
+    - avoid_redundant_argument_values
+
     # package or relative? Let's end the discussion and use package everywhere.
     # pedantic: enabled
     # https://dart-lang.github.io/linter/lints/avoid_relative_lib_imports.html
@@ -767,6 +772,11 @@ linter:
     # pedantic: enabled
     # https://dart-lang.github.io/linter/lints/use_function_type_syntax_for_parameters.html
     - use_function_type_syntax_for_parameters
+
+    # Adding a key without using it isn't helpful in applications, only for the Flutter SDK
+    # Dart SDK: >= 2.8.0-dev.1.0 • (Linter v0.1.108)
+    # https://dart-lang.github.io/linter/lints/use_key_in_widget_constructors.html
+    # - use_key_in_widget_constructors
 
     # Use rethrow to preserve the original stacktrace.
     # https://dart.dev/guides/language/effective-dart/usage#do-use-rethrow-to-rethrow-a-caught-exception

--- a/lib/analysis_options_package.yaml
+++ b/lib/analysis_options_package.yaml
@@ -8,14 +8,17 @@ include: package:lint/analysis_options.yaml
 linter:
   rules:
     # Good for libraries to prevent unnecessary code paths.
+    # Dart SDK: >= 2.0.0 • (Linter v0.1.25)
     # https://dart-lang.github.io/linter/lints/literal_only_boolean_expressions.html
     - literal_only_boolean_expressions
 
     # One of the most important rules. Docs for package public APIs make a good package.
     # Like catching undocumented code? Enable `public_member_api_docs` as well.
+    # Dart SDK: >= 2.0.0 • (Linter v0.1.1)
     # https://dart-lang.github.io/linter/lints/package_api_docs.html
     - package_api_docs
 
     # Too strict. Implementing all exported public APIs (`package_api_docs`) is enough.
+    # Dart SDK: >= 2.0.0 • (Linter v0.1.11)
     # https://dart-lang.github.io/linter/lints/public_member_api_docs.html
     # - public_member_api_docs

--- a/lib/analysis_options_package.yaml
+++ b/lib/analysis_options_package.yaml
@@ -22,3 +22,8 @@ linter:
     # Dart SDK: >= 2.0.0 • (Linter v0.1.11)
     # https://dart-lang.github.io/linter/lints/public_member_api_docs.html
     # - public_member_api_docs
+
+    # Adding a key without using it isn't helpful in applications, only for the Flutter SDK
+    # Dart SDK: >= 2.8.0-dev.1.0 • (Linter v0.1.108)
+    # https://dart-lang.github.io/linter/lints/use_key_in_widget_constructors.html
+    - use_key_in_widget_constructors

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lint
-version: 1.2.0-dev.d28.2
+version: 1.2.0
 description: An opiniated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter
 homepage: https://github.com/passsy/dart-lint
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lint
-version: 1.1.1
+version: 1.2.0-dev.d28.1
 description: An opiniated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter
 homepage: https://github.com/passsy/dart-lint
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lint
-version: 1.2.0-dev.d28.1
+version: 1.2.0-dev.d28.2
 description: An opiniated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter
 homepage: https://github.com/passsy/dart-lint
 
 environment:
-  sdk: '>=2.8.0-dev.1.0 <3.0.0'
+  sdk: '>=2.8.0-dev.16.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,4 +4,4 @@ description: An opiniated, community-driven set of lint rules for Dart and Flutt
 homepage: https://github.com/passsy/dart-lint
 
 environment:
-  sdk: '>=2.8.0 <3.0.0'
+  sdk: '>=2.8.0-dev.1.0 <3.0.0'


### PR DESCRIPTION
Release for [Dart 2.8.1](https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md#281---2020-05-06)

Updates to Linter v0.1.114 

Since 114 didn't add new lint rules the min sdk can be set to the [update to 113](https://github.com/dart-lang/sdk/commit/0e0d4fb76b58cd5a2b2458b043efd5f2b5254a2a) which was first released with `2.8.0-dev.16.0`