### PR TITLE
Dart 2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changlog
 
+## 1.4.0-dev.d210.1
+
+Release for Dart 2.10.0 with Linter v0.1.118
+
+Min SDK is `2.10.0-5.0.dev`
+
+- Enable [`use_late_for_private_fields_and_variables`](https://dart-lang.github.io/linter/lints/use_late_for_private_fields_and_variables.html)
+- Enable [`unnecessary_nullable_for_final_variable_declarations`](https://dart-lang.github.io/linter/lints/unnecessary_nullable_for_final_variable_declarations.html)
+
 ## 1.3.0
 
 Release for Dart 2.9.0 with Linter v0.1.117

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changlog
 
+## 1.5.0
+
+Min SDK is `2.12.0`
+
+- NNBD support
+
 ## 1.4.0-dev.d210.1
 
 Release for Dart 2.10.0 with Linter v0.1.118

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -784,6 +784,11 @@ linter:
     # https://dart-lang.github.io/linter/lints/unnecessary_null_in_if_null_operators.html
     - unnecessary_null_in_if_null_operators
 
+    # If a variable doesn't change and is initialized, no need to define it as nullable (NNDB)
+    # Dart SDK: >= 2.10.0-10.0.dev • (Linter v0.1.118)
+    # https://dart-lang.github.io/linter/lints/unnecessary_nullable_for_final_variable_declarations.html
+    - unnecessary_nullable_for_final_variable_declarations
+
     # Remove overrides which simply call super
     # https://dart-lang.github.io/linter/lints/unnecessary_overrides.html
     - unnecessary_overrides
@@ -838,6 +843,11 @@ linter:
     # Dart SDK: >= 2.8.0-dev.1.0 • (Linter v0.1.108)
     # https://dart-lang.github.io/linter/lints/use_key_in_widget_constructors.html
     # - use_key_in_widget_constructors
+
+    # Still unsure if `late` is always better than `!` (NNBD)
+    # Dart SDK: >= 2.10.0-10.0.dev • (Linter v0.1.118)
+    # https://dart-lang.github.io/linter/lints/use_late_for_private_fields_and_variables.html
+    - use_late_for_private_fields_and_variables
 
     # Use rethrow to preserve the original stacktrace.
     # https://dart.dev/guides/language/effective-dart/usage#do-use-rethrow-to-rethrow-a-caught-exception

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: lint
-version: 1.4.0-dev.d210.1
+version: 1.5.0
 description: An opiniated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter
 homepage: https://github.com/passsy/dart-lint
 
 environment:
-  sdk: '>=2.10.0-10.0.dev <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lint
-version: 1.3.0
+version: 1.4.0-dev.d210.1
 description: An opiniated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter
 homepage: https://github.com/passsy/dart-lint
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,4 +4,4 @@ description: An opiniated, community-driven set of lint rules for Dart and Flutt
 homepage: https://github.com/passsy/dart-lint
 
 environment:
-  sdk: '>=2.9.0-16.0.dev <3.0.0'
+  sdk: '>=2.10.0-10.0.dev <3.0.0'


### PR DESCRIPTION
NNBD release.

It's only to enable support for nnbd. More rules for older version will continue to land in `1.4.*`

not a `-nullsafety` preview release because this package has no code which could break.