### PR TITLE
Enable unawaited_futures, ship fireAndForget 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <img src="https://user-images.githubusercontent.com/1096485/66209493-bc0ec900-e6b7-11e9-80c6-222e778f0c8d.png">
 </p>
 
-`lint` is a hand-picked, open-source, community-driven collection of lint rules for Dart and Flutter projects.
+`lint` is an opinionated, hand-picked, open-source, community-driven **collection** of lint rules for Dart and Flutter projects.
 The set of rules follows the [Effective Dart: Style Guide](https://dart.dev/guides/language/effective-dart/style).
 
 This package can be used as a replacement for [`package:pedantic`](https://github.com/dart-lang/pedantic) for those who prefer stricter rules.

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -763,12 +763,29 @@ linter:
     # https://dart-lang.github.io/linter/lints/type_init_formals.html
     - type_init_formals
 
-    # Too many false positives.
-    # Using the pedantic package for the unawaited function doesn't make code better readable
+    # Catches common mistakes where `await` was accidentally forgotten.
+    # The lint can be ignored by wrapping the Future in any function or calling a function on it. Lint provides the
+    # `fireAndForget` function and extension which can be used.
     #
+    # ```
+    # Future<void> logAsync(String msg) async { /*...*/ }
+    #
+    # Future<void> someOperation() async {
+    #   await doSomething();
+    #
+    #   // This alone triggers the lint because await is missing
+    #   logAsync('success');
+    #
+    #   // The fireAndForget() extensions signals that await is intentionally missing
+    #   logAsync('success').fireAndForget();
+    #
+    #   // The fireAndForget() function signals that await is intentionally missing
+    #   fireAndForget(logAsync('success'));
+    # }
+    # ```
     # pedantic: enabled
     # https://dart-lang.github.io/linter/lints/unawaited_futures.html
-    # - unawaited_futures
+    - unawaited_futures
 
     # Remove async/await clutter when not required
     # https://dart-lang.github.io/linter/lints/unnecessary_await_in_return.html

--- a/lib/fire_and_forget.dart
+++ b/lib/fire_and_forget.dart
@@ -1,0 +1,66 @@
+/// Indicates to tools that [future] is intentionally not `await`-ed.
+///
+/// In an `async` context, it is normally expected that all [Future]s are
+/// awaited, and that is the basis of the lint `unawaited_futures`. However,
+/// there are times where one or more futures are intentionally not awaited.
+/// This function may be used to ignore a particular future. It silences the
+/// `unawaited_futures` lint.
+///
+/// ## Usage
+///
+/// ```dart
+/// Future<void> logAsync(String msg) async { /*...*/ }
+///
+/// Future<void> someOperation() async {
+///   await doSomething();
+///
+///   // This alone triggers the lint because await is missing
+///   logAsync('success');
+///
+///   // The fireAndForget() function signals that await is intentionally missing
+///   fireAndForget(logAsync('success'));
+/// }
+/// ```
+///
+/// ## Extension vs. wrapper function
+///
+/// `fireAndForget` can also be used as extension, see [FireAndForget].
+///
+/// The extensions should be preferred as it is
+/// - easier to read and
+/// - doesn't break formatting of method chains.
+/// src: https://github.com/dart-lang/sdk/issues/32280#issuecomment-372060804
+///
+/// The top-level function is useful because it gets autocompleted in IDEs without writing the import first.
+/// This is still not possible for extension functions https://github.com/dart-lang/sdk/issues/38894.
+void fireAndForget<T>(Future<void>? future) {}
+
+/// Hosts the `fireAndForget` extension to silence the `unawaited_futures` warning.
+extension FireAndForget on Future<void>? {
+  /// Indicates to tools that [Future] is intentionally not `await`-ed.
+  ///
+  /// In an `async` context, it is normally expected that all [Future]s are
+  /// awaited, and that is the basis of the lint `unawaited_futures`. However,
+  /// there are times where one or more futures are intentionally not awaited.
+  /// This function may be used to ignore a particular future. It silences the
+  /// `unawaited_futures` lint.
+  ///
+  /// ## Usage
+  ///
+  /// ```dart
+  /// Future<void> logAsync(String msg) async { /*...*/ }
+  ///
+  /// Future<void> someOperation() async {
+  ///   await doSomething();
+  ///
+  ///   // This alone triggers the lint because await is missing
+  ///   logAsync('success');
+  ///
+  ///   // The fireAndForget() extensions signals that await is intentionally missing
+  ///   logAsync('success').fireAndForget();
+  /// }
+  /// ```
+  ///
+  /// `fireAndForget` is also available as top-level function `fireAndForget()` which wraps a Future
+  void fireAndForget() {}
+}

--- a/lib/lint.dart
+++ b/lib/lint.dart
@@ -1,4 +1,4 @@
-/// The lint package doesn't ship any dart source code.
+/// The lint package ships an opinionated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter
 ///
 /// To enable `lint`,
 /// 1. Add it to your dev_dependencies
@@ -12,3 +12,5 @@
 /// include: package:lint/analysis_options.yaml
 /// ```
 library lint;
+
+export 'package:lint/fire_and_forget.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lint
 version: 1.5.3
-description: An opiniated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter
+description: An opinionated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter
 homepage: https://github.com/passsy/dart-lint
 
 environment:


### PR DESCRIPTION
Enables `unawaited_futures`. 

Where Futures are intentionally not awaited, users can disable this lint with `fireAndForget` which exists as top-level function and extension. It is identical to [`unawaited`](https://github.com/google/pedantic/blob/master/lib/pedantic.dart) from pedantic.

```dart
Future<void> logAsync(String msg) async { /*...*/ }

Future<void> someOperation() async {
  await doSomething();

  // Warning: `Future` results in `async` function bodies must be `await`ed or marked `unawaited` using `package:pedantic`.
  logAsync('success');

  // The fireAndForget() extensions signals that await is intentionally missing
  logAsync('success').fireAndForget();

  // The fireAndForget() function signals that await is intentionally missing
  fireAndForget(logAsync('success'));
}
```

I explicitly did not name it `unawaited` as it causes naming conflicts. That's the main reason why `unawaited` was removed from `meta` again.

Fixes #26 

### Alternative names

- `notAwaited`
- `runInParallel`
- `ignoreUnawaitedFuture`
