### PR TITLE
Fix typo `opiniated` in `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lint
 version: 1.8.0
-description: An opiniated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter
+description: An opinionated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter
 homepage: https://github.com/passsy/dart-lint
 
 environment:


### PR DESCRIPTION
I'm not really sure, but I think you mean `opinionated`, because there is no word in the English language like `opiniated` (https://en.wiktionary.org/wiki/opiniated).