### PR TITLE
Enable unnecessary_late linter rule

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -958,6 +958,12 @@ linter:
     # https://dart-lang.github.io/linter/lints/unnecessary_lambdas.html
     # - unnecessary_lambdas
 
+    # Don't specify the late modifier for top-level and static variables when the declaration contains an initializer.
+    # 
+    # Dart SDK: >= 2.10.0-0.0.dev • (Linter v0.1.117)
+    # https://dart-lang.github.io/linter/lints/unnecessary_late.html
+    - unnecessary_late
+
     # Remove the optional `new` keyword
     #
     # https://dart-lang.github.io/linter/lints/unnecessary_new.html


### PR DESCRIPTION
This rule is also enabled in the official lints package as part of the recommended rule set: https://github.com/dart-lang/lints/blob/main/lib/recommended.yaml