### PR TITLE
Add new dart 3.1 lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.2.0
+
+Requires Dart `sdk: '>=3.1.0'`
+
+- Enable [`no_wildcard_variable_uses`](https://dart-lang.github.io/linter/lints/no_wildcard_variable_uses.html)
+- Enable [`no_self_assignments`](https://dart-lang.github.io/linter/lints/no_self_assignments.html)
+
 ## 2.1.2
 
 Requires Dart `sdk: '>=3.0.0'`

--- a/lib/casual.yaml
+++ b/lib/casual.yaml
@@ -610,6 +610,20 @@ linter:
     # https://dart-lang.github.io/linter/lints/no_runtimeType_toString.html
     - no_runtimeType_toString
 
+    # Don’t assign a variable to itself.
+    #
+    # Dart SDK: >= 3.1.0
+    #
+    # https://dart.dev/tools/linter-rules/no_self_assignments
+    - no_self_assignments
+
+    # Don’t use wildcard parameters or variables. Code using this will break in the future.
+    #
+    # Dart SDK: >= 3.1.0
+    #
+    # https://dart.dev/tools/linter-rules/no_wildcard_variable_uses
+    - no_wildcard_variable_uses
+
     # Follow dart style naming conventions
     #
     # https://dart-lang.github.io/linter/lints/non_constant_identifier_names.html
@@ -1253,16 +1267,3 @@ linter:
     # Don't assign anything to void
     # https://dart-lang.github.io/linter/lints/void_checks.html
     - void_checks
-    # Don’t use wildcard parameters or variables. Code using this will break in the future.
-    #
-    # Dart SDK: >= 3.1.0
-    #
-    # https://dart.dev/tools/linter-rules/no_wildcard_variable_uses
-    - no_wildcard_variable_uses
-
-    # Don’t assign a variable to itself.
-    #
-    # Dart SDK: >= 3.1.0
-    #
-    # https://dart.dev/tools/linter-rules/no_self_assignments
-    - no_self_assignments

--- a/lib/casual.yaml
+++ b/lib/casual.yaml
@@ -1253,3 +1253,16 @@ linter:
     # Don't assign anything to void
     # https://dart-lang.github.io/linter/lints/void_checks.html
     - void_checks
+    # Don’t use wildcard parameters or variables. Code using this will break in the future.
+    #
+    # Dart SDK: >= 3.1.0
+    #
+    # https://dart.dev/tools/linter-rules/no_wildcard_variable_uses
+    - no_wildcard_variable_uses
+
+    # Don’t assign a variable to itself.
+    #
+    # Dart SDK: >= 3.1.0
+    #
+    # https://dart.dev/tools/linter-rules/no_self_assignments
+    - no_self_assignments

--- a/lib/strict.yaml
+++ b/lib/strict.yaml
@@ -613,6 +613,20 @@ linter:
     # https://dart-lang.github.io/linter/lints/no_runtimeType_toString.html
     - no_runtimeType_toString
 
+    # Don’t use wildcard parameters or variables. Code using this will break in the future.
+    #
+    # Dart SDK: >= 3.1.0
+    #
+    # https://dart.dev/tools/linter-rules/no_wildcard_variable_uses
+    - no_wildcard_variable_uses
+
+    # Don’t assign a variable to itself.
+    #
+    # Dart SDK: >= 3.1.0
+    #
+    # https://dart.dev/tools/linter-rules/no_self_assignments
+    - no_self_assignments
+
     # Follow dart style naming conventions
     #
     # https://dart-lang.github.io/linter/lints/non_constant_identifier_names.html
@@ -1256,16 +1270,3 @@ linter:
     # Don't assign anything to void
     # https://dart-lang.github.io/linter/lints/void_checks.html
     - void_checks
-    # Don’t use wildcard parameters or variables. Code using this will break in the future.
-    #
-    # Dart SDK: >= 3.1.0
-    #
-    # https://dart.dev/tools/linter-rules/no_wildcard_variable_uses
-    - no_wildcard_variable_uses
-
-    # Don’t assign a variable to itself.
-    #
-    # Dart SDK: >= 3.1.0
-    #
-    # https://dart.dev/tools/linter-rules/no_self_assignments
-    - no_self_assignments

--- a/lib/strict.yaml
+++ b/lib/strict.yaml
@@ -1256,3 +1256,16 @@ linter:
     # Don't assign anything to void
     # https://dart-lang.github.io/linter/lints/void_checks.html
     - void_checks
+    # Don’t use wildcard parameters or variables. Code using this will break in the future.
+    #
+    # Dart SDK: >= 3.1.0
+    #
+    # https://dart.dev/tools/linter-rules/no_wildcard_variable_uses
+    - no_wildcard_variable_uses
+
+    # Don’t assign a variable to itself.
+    #
+    # Dart SDK: >= 3.1.0
+    #
+    # https://dart.dev/tools/linter-rules/no_self_assignments
+    - no_self_assignments

--- a/lib/strict.yaml
+++ b/lib/strict.yaml
@@ -613,19 +613,19 @@ linter:
     # https://dart-lang.github.io/linter/lints/no_runtimeType_toString.html
     - no_runtimeType_toString
 
-    # Don’t use wildcard parameters or variables. Code using this will break in the future.
-    #
-    # Dart SDK: >= 3.1.0
-    #
-    # https://dart.dev/tools/linter-rules/no_wildcard_variable_uses
-    - no_wildcard_variable_uses
-
     # Don’t assign a variable to itself.
     #
     # Dart SDK: >= 3.1.0
     #
     # https://dart.dev/tools/linter-rules/no_self_assignments
     - no_self_assignments
+
+    # Don’t use wildcard parameters or variables. Code using this will break in the future.
+    #
+    # Dart SDK: >= 3.1.0
+    #
+    # https://dart.dev/tools/linter-rules/no_wildcard_variable_uses
+    - no_wildcard_variable_uses
 
     # Follow dart style naming conventions
     #

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lint
-version: 2.1.2
+version: 2.2.0
 description: An opinionated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter
 repository: https://github.com/passsy/dart-lint
 issue_tracker: https://github.com/passsy/dart-lint/issues
@@ -7,4 +7,4 @@ topics:
   - lint
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
closes #https://github.com/passsy/dart-lint/issues/69

Two new lints where added to the official [linter](https://github.com/dart-lang/linter/blob/main/CHANGELOG.md)

[`no_wildcard_variable_uses`](https://dart-lang.github.io/linter/lints/no_wildcard_variable_uses.html)
and
[`no_self_assignments`](https://dart-lang.github.io/linter/lints/no_self_assignments.html)

Both seem to be reasonable to  me.

[Linter got rid of it's versioning scheme](https://github.com/dart-lang/linter/issues/4389) and is now in step with the dart versioning so i left it out.