### PR TITLE
Add dart 3.2 lint rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.0
+
+Requires Dart `sdk: '>=3.2.0'`
+
+- Enable [`annotate_redeclares`](https://dart.dev/tools/linter-rules/annotate_redeclares.html)
+
 ## 2.2.0
 
 Requires Dart `sdk: '>=3.1.0'`

--- a/lib/casual.yaml
+++ b/lib/casual.yaml
@@ -77,6 +77,13 @@ linter:
     # http://dart-lang.github.io/linter/lints/annotate_overrides.html
     - annotate_overrides
 
+    # Annotate redeclared members. Experimental.
+    #
+    # Dart SDK: >= 3.2.0
+    #
+    # https://dart.dev/tools/linter-rules/annotate_redeclares.html
+    - annotate_redeclares
+
     # All methods should define a return type. dynamic is no exception.
     # Violates Effective Dart "PREFER annotating with dynamic instead of letting inference fail"
     #

--- a/lib/strict.yaml
+++ b/lib/strict.yaml
@@ -80,6 +80,13 @@ linter:
     # http://dart-lang.github.io/linter/lints/annotate_overrides.html
     - annotate_overrides
 
+    # Annotate redeclared members. Experimental.
+    #
+    # Dart SDK: >= 3.2.0
+    #
+    # https://dart.dev/tools/linter-rules/annotate_redeclares.html
+    - annotate_redeclares
+
     # All methods should define a return type. dynamic is no exception.
     # Violates Effective Dart "PREFER annotating with dynamic instead of letting inference fail"
     #

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lint
-version: 2.2.0
+version: 2.3.0
 description: An opinionated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter
 repository: https://github.com/passsy/dart-lint
 issue_tracker: https://github.com/passsy/dart-lint/issues
@@ -7,4 +7,4 @@ topics:
   - lint
 
 environment:
-  sdk: '>=3.1.0 <4.0.0'
+  sdk: '>=3.2.0 <4.0.0'


### PR DESCRIPTION
This adds the [`annotate_redeclares`](https://dart.dev/tools/linter-rules/annotate_redeclares.html) rule from `dart 3.2`.

The rule seems exotic but helpful.

To better reason about i created [this dartpad](https://dartpad.dev/?id=a88b945512869350b8e2ac9a849868a5&channel=master).

Does it make sense to you to have it enabled?