### PR TITLE
Disable document_ignores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.2
+
+- Disable [`document_ignores`](https://dart.dev/tools/linter-rules/document_ignores.html) due to unnecessary verbosity
+
 ## 2.6.1
 
 Requires Dart `sdk: '>=3.5.0'`

--- a/lib/strict.yaml
+++ b/lib/strict.yaml
@@ -427,12 +427,22 @@ linter:
     # https://dart.dev/tools/linter-rules/do_not_use_environment
     # - do_not_use_environment
 
-    # Ensures that ignore comments are properly documented with a reason
+    # The reason for the ignore is usually self-evident and an additional comment would add unnecessary verbosity.
+    # Also, when temporarily ignoring rules for debugging or development purposes, having to add documentation creates unnecessary overhead
+    #
+    # Example where it is annoying:
+    #
+    # ```dart
+    # } catch (e, stack) {
+    #   // ignore: avoid_print
+    #   print(stack);
+    # }
+    # ```
     #
     # Dart SDK: >= 3.5.0
     #
     # https://dart.dev/tools/linter-rules/document_ignores
-    - document_ignores
+    # - document_ignores
 
     # Add a comment why no further error handling is required
     #

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: lint
-version: 2.6.1
+version: 2.6.2
 description: An opinionated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter
 repository: https://github.com/passsy/dart-lint
 issue_tracker: https://github.com/passsy/dart-lint/issues


### PR DESCRIPTION
It was introduced with Dart 3.5, but added to much verbosity for each ignore